### PR TITLE
Update pdns-qof.xml

### DIFF
--- a/i-d/pdns-qof.xml
+++ b/i-d/pdns-qof.xml
@@ -245,7 +245,7 @@ ws              = *(
             <t>This field returns the last time that the unique tuple (rrname, rrtype, rdata) record has been seen via master file import. The date is expressed in seconds (decimal) since 1st of January 1970 (Unix timestamp). The time zone MUST be UTC. This field is represented as a <xref target="RFC4627">JSON</xref> number.</t>
             </section>
             <section title="origin">
-                    <t>Specifies the resource origin of the Passive DNS response. This field is represented as a <xref target="RFC3986">Uniform Resource Identifier</xref> (URI).
+                    <t>Specifies the resource origin of the Passive DNS response. This field is represented as a <xref target="RFC1035">Domain Name</xref> (URI).
             </t>
             </section>
 


### PR DESCRIPTION
origin can't be a URI because the responder has no reason to know the access method (HTTP vs HTTPS for example, or others in the future) that the requestor used to reach the service. what's important is to provide a unique origin name for this row, so as to disambiguate it from other rows which may have the same name and type but a different rrset. for that we need only a domain name, which we might actually prefer to represent in the web's and SNMP's resource style, as in, .info.dnsdb.api rather than api.dnsdb.info. for now i've assumed that we'll use a domain name, which will be the service's understanding of its advertised name, rather than as a URI, which could include a lot of details that the origin server will not know. if a URI is given by some pre-standard server, then only its domain name will be meaningful.